### PR TITLE
#69 Rename the topic to a pack.

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -27,7 +27,7 @@ var initCmd = &cobra.Command{
 		// Create a project.
 		projectName, err := services.Project.Create(name)
 		if err != nil {
-			fmt.Println(err)
+			fmt.Printf("An error occurred while creating the project: %s\n", err)
 			os.Exit(1)
 		}
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,11 +1,11 @@
 job:
   name: "nginx"
   datacenters: ["dc1"]
-  type: "service" # type from topic, default "service"
-  namespace: "default"
+  type: "service" # type from pack, default "service"
+  namespace: "default" # set in the deployment command flag
 
   meta:
-    run_uuid: "uuid4" # deploy_version from topic
+    run_uuid: "uuid4" # deploy_version from pack
 
   group:
     - name: "nginx"
@@ -19,8 +19,6 @@ job:
             to: 80
           - name: "https"
             to: 443
-          - name: "test"
-            static: 81
 
       scaling:
         enabled: true
@@ -31,14 +29,14 @@ job:
         - name: "nginx"
           provider: "consul"
           port: "http"
-          tags: ["nginx", "test"]
+          tags: ["nginx"]
 
           check:
-            name: "alive"
-            type: "http"
-            path: "/"
-            interval: "10s"
-            timeout: "2s"
+            - name: "alive"
+              type: "http"
+              path: "/"
+              interval: "10s"
+              timeout: "2s"
 
           connect:
             open_sidecar_service: true
@@ -46,7 +44,7 @@ job:
         - name: "nginx-https"
           provider: "consul"
           port: "https"
-          tags: ["nginx", "test"]
+          tags: ["nginx"]
 
           connect:
             sidecar_service:

--- a/config/prism.yaml
+++ b/config/prism.yaml
@@ -1,12 +1,31 @@
-name: "test"
-description: "A Helm chart for Kubernetes"
+# The name of the Prism Pack.
+name: "PRISM_PACK_NAME"
+
+# Description of the Prism Pack.
+description: "A prism pack for Nomad"
+
+# Specifies the Nomad scheduler to use.
+# Nomad provides the service, system, batch, and sysbatch schedulers.
 type: "service"
 
+# Links to source code or resources associated with the Prism Pack.
+sources:
+  # - https://github.com/prometheus-operator/kube-prometheus
+
+# The version of the application it contains.
 deploy_version: "0.0.1"
+
+# The version of the Prism Pack,
+# aiding in tracking changes and updates to the Prism Pack.
 prism_version: "0.0.1"
 
-dependencies:
-  - name: "rabbit"
-    prism_version: "1.0"
-    path: "project/charts/rabbit"
-    config_path: "project/env/prod/config/rabbit_config.yaml"
+# The version of Nomad on which the Prism Pack has been tested.
+nomadVer: 1.6.1
+
+# Specifies dependencies of the current Prism Pack on other Prism Packs,
+# which will be automatically installed when installing the main Prism Pack.
+# dependencies:
+#   - name: "rabbit"
+#     prism_version: "0.0.1"
+#     path: "project/pack/rabbit"
+#     config_path: "project/env/prod/config/rabbit_config.yaml"

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -19,11 +19,13 @@ type TemplateBlock struct {
 	Block     []TemplateBlock          // list of configuration blocks
 }
 
+// Necessary data for building the job configuration structure.
 type BuildStructure struct {
 	Config       ConfigBlock
 	FilesDirPath string
 }
 
+// Job deployment data.
 type ConfigParameter struct {
 	ProjectDir     string
 	ProjectDirPath string
@@ -42,12 +44,12 @@ type Changes struct {
 	Release   string
 	Namespace string
 	Files     []TemplateBlock
-	Topic     ConfigBlock
+	Pack      ConfigBlock
 }
 
 type BlockChanges struct {
 	Release   string
 	Namespace string
 	File      TemplateBlock
-	Topic     ConfigBlock
+	Pack      ConfigBlock
 }

--- a/internal/service/builder/changes.go
+++ b/internal/service/builder/changes.go
@@ -28,7 +28,7 @@ func (s *Changes) SetChanges(
 		Release:   changes.Release,
 		Namespace: changes.Namespace,
 		File:      model.TemplateBlock{},
-		Topic:     changes.Topic,
+		Pack:      changes.Pack,
 	}
 
 	if len(changes.Files) > 0 {
@@ -48,7 +48,6 @@ func (s *Changes) SetChanges(
 	}
 
 	job(config, &blockChanges)
-
 	return nil
 }
 
@@ -240,7 +239,7 @@ func checkFileChanges(
 		Release:   changes.Release,
 		Namespace: changes.Namespace,
 		File:      fileChanges,
-		Topic:     changes.Topic,
+		Pack:      changes.Pack,
 	}
 
 	return blockChanges

--- a/internal/service/deployment/config.go
+++ b/internal/service/deployment/config.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"prism/internal/model"
 	"regexp"
-	"strings"
 )
 
 // Returns the configuration structure.
@@ -15,42 +14,41 @@ func (s *Deployment) CreateConfigStructure(
 ) (model.TemplateBlock, error) {
 	var config model.TemplateBlock
 
-	// Topic.
-	topicName := strings.ReplaceAll(parameter.ProjectDir, "-", "_")
-	topicFileName := fmt.Sprintf("%s.yaml", topicName)
-	topicPath := filepath.Join(parameter.ProjectDirPath, topicFileName)
+	// Pack.
+	packFileName := "prism.yaml"
+	packPath := filepath.Join(parameter.ProjectDirPath, packFileName)
 
-	topicFile, err := os.ReadFile(topicPath)
+	packFile, err := os.ReadFile(packPath)
 	if err != nil {
-		return config, fmt.Errorf("error to read topic file, %s", err)
+		return config, fmt.Errorf("error to read pack file, %s", err)
 	}
 
-	parsedTopicConfig, err := s.parser.ParseYAML(topicFile)
+	parsedPackConfig, err := s.parser.ParseYAML(packFile)
 	if err != nil {
 		if err != nil {
-			return config, fmt.Errorf("failed to parsing topic file, %s", err)
+			return config, fmt.Errorf("failed to parsing pack file, %s", err)
 		}
 	}
 
-	topicConfig := s.parser.ParseConfig("topic", parsedTopicConfig)
+	packConfig := s.parser.ParseConfig("pack", parsedPackConfig)
 
-	// Job.
-	jobFileName := "config.yaml"
-	jobPath := filepath.Join(parameter.ProjectDirPath, jobFileName)
+	// Job config.
+	configFileName := "config.yaml"
+	configPath := filepath.Join(parameter.ProjectDirPath, configFileName)
 
-	jobFile, err := os.ReadFile(jobPath)
+	configFile, err := os.ReadFile(configPath)
 	if err != nil {
 		return config, fmt.Errorf("error to read job file, %s", err)
 	}
 
-	parsedJobConfig, err := s.parser.ParseYAML(jobFile)
+	parsedConfig, err := s.parser.ParseYAML(configFile)
 	if err != nil {
-		return config, fmt.Errorf("failed to parsing job file, %s", err)
+		return config, fmt.Errorf("failed to parsing job config file, %s", err)
 	}
 
 	jobConfig := s.parser.ParseConfig(
 		"job",
-		parsedJobConfig["job"].(map[string]interface{}),
+		parsedConfig["job"].(map[string]interface{}),
 	)
 
 	// Config structure.
@@ -128,7 +126,7 @@ func (s *Deployment) CreateConfigStructure(
 		Release:   parameter.Release,
 		Namespace: parameter.Namespace,
 		Files:     files,
-		Topic:     topicConfig,
+		Pack:      packConfig,
 	}
 
 	err = s.changes.SetChanges(&config, &changes)


### PR DESCRIPTION
- Renamed the topic file to a pack.
- The pack file will now always be named prism rather than the directory (project), name.
- Pack file updated.
- The name parameter in the pack file is now assigned the name of the pack (project).
- Updated error messages when creating a project.